### PR TITLE
Downloading oneconfig directly

### DIFF
--- a/oneconfig/failed-to-download.md
+++ b/oneconfig/failed-to-download.md
@@ -48,3 +48,7 @@ North Korea
 China
 
 </details>
+
+## Download OneConfig directly
+
+If you are still unable to download OneConfig, you may want to download it manually. You can do that by clicking [here](https://api.polyfrost.org/oneconfig/1.8.9-forge). When the file is finished downloading it, move it to `.minecraft/OneConfig`, if this folder does not exist create it, then rename it to `OneConfig (1.8.9-forge).jar`. You can now try launching again.

--- a/oneconfig/failed-to-download.md
+++ b/oneconfig/failed-to-download.md
@@ -30,7 +30,7 @@ Since OneConfig downloads its core files from another server, some antiviruses w
 
 * Make sure all antivirus software is up-to-date
 * Check that your antivirus isn't blocking OneConfig or other Polyfrost services
-
+z
 ## Using a VPN
 
 Occasionally, your ISP (internet service provider) or country may block access to certain websites such as GitHub or our own services. Using a [VPN](https://1.1.1.1/dns/) can allow you, to some extent circumvent these issues.
@@ -51,4 +51,5 @@ China
 
 ## Download OneConfig directly
 
-If you are still unable to download OneConfig, you may want to download it manually. You can do that by clicking [here](https://api.polyfrost.org/oneconfig/1.8.9-forge). When the file is finished downloading, move it to `.minecraft/OneConfig`, if this folder does not exist create it. Once relocated, rename the jar file that you downloaded from the link to `OneConfig (1.8.9-forge).jar`. You can then try launching the game to see if OneConfig is present.
+If you are still unable to download OneConfig, you may want to download it manually. Start by opening [this](https://api.polyfrost.org/oneconfig/1.8.9-forge). Here, highlight the first link (do not highlight the quotation marks), right click and press "go to https://...." ![image](https://github.com/user-attachments/assets/7b8bfd4f-0ab3-493e-ac32-fffec7a32dfb)
+Upon clicking this, it will download a file, when that file is finished downloading, move it to `<your minecraft folder>/OneConfig`, if this folder does not exist create it. Once relocated, rename the jar file that you downloaded from the link to `OneConfig (1.8.9-forge).jar`. You can then try launching the game to see if OneConfig is present.

--- a/oneconfig/failed-to-download.md
+++ b/oneconfig/failed-to-download.md
@@ -30,7 +30,7 @@ Since OneConfig downloads its core files from another server, some antiviruses w
 
 * Make sure all antivirus software is up-to-date
 * Check that your antivirus isn't blocking OneConfig or other Polyfrost services
-z
+
 ## Using a VPN
 
 Occasionally, your ISP (internet service provider) or country may block access to certain websites such as GitHub or our own services. Using a [VPN](https://1.1.1.1/dns/) can allow you, to some extent circumvent these issues.

--- a/oneconfig/failed-to-download.md
+++ b/oneconfig/failed-to-download.md
@@ -51,4 +51,4 @@ China
 
 ## Download OneConfig directly
 
-If you are still unable to download OneConfig, you may want to download it manually. You can do that by clicking [here](https://api.polyfrost.org/oneconfig/1.8.9-forge). When the file is finished downloading it, move it to `.minecraft/OneConfig`, if this folder does not exist create it, then rename it to `OneConfig (1.8.9-forge).jar`. You can now try launching again.
+If you are still unable to download OneConfig, you may want to download it manually. You can do that by clicking [here](https://api.polyfrost.org/oneconfig/1.8.9-forge). When the file is finished downloading, move it to `.minecraft/OneConfig`, if this folder does not exist create it. Once relocated, rename the jar file that you downloaded from the link to `OneConfig (1.8.9-forge).jar`. You can then try launching the game to see if OneConfig is present.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
i added the thing
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #
you
## How to test
<!-- Provide steps to test this PR -->
with thines eyes
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
```
added documentation to download oneconfig directly to your .minecraft from the api link
## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
--> this is the docs